### PR TITLE
Support PHP ^8.1 and Laravel 9

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,12 @@
 Laravel-money is an open source library that simplifies life to convert numbers from a database (`'balance': 12340`) into money objects.
 With all being said, you can calculate money, output it as a string, convert it between currencies online via API services as well as offline and more!
 
+## Upgrade guide
+
+- [`3.x` to `4.x`](/docs/upgrade/3.x_to_4.x.md)
+
 ## Requirements
-- PHP: `^7.4` or `^8.0`
+- PHP: `^8.1`
 - `guzzlehttp/guzzle`: `^7.0`
 
 ## Installation

--- a/composer.json
+++ b/composer.json
@@ -11,13 +11,13 @@
         }
     ],
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "guzzlehttp/guzzle": "^7.0",
         "spatie/laravel-package-tools": "^1.12"
     },
     "require-dev": {
-        "orchestra/testbench": "^6.15",
+        "orchestra/testbench": "^7.0",
         "squizlabs/php_codesniffer": "^3.6",
         "slevomat/coding-standard": "^7.0"
     },

--- a/docs/upgrade/3.x_to_4.x.md
+++ b/docs/upgrade/3.x_to_4.x.md
@@ -1,0 +1,8 @@
+# 🧰 Upgrade guide from `3.x` to `4.x`
+
+## PHP and Laravel versions
+- PHP: `^8.1`
+- Laravel: `9`
+
+This version drops support of PHP < 8.1 and now supports Laravel 9.
+This was made in order to keep pace with new versions and use new features.


### PR DESCRIPTION
This PR drops support of PHP < 8.1 and now supports Laravel 9.
This was made in order to keep pace with new versions and use new features.