### PR TITLE
Rename multiple method

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ After all, the config file at `config/money.php` should be modified for your own
         - Calculations
             - [`add()`](/docs/04_money/object/add.md)
             - [`subtract()`](/docs/04_money/object/subtract.md)
-            - [`multiple()`](/docs/04_money/object/multiple.md)
+            - [`multiply()`](/docs/04_money/object/multiply.md)
             - [`divide()`](/docs/04_money/object/divide.md)
             - [`rebase()`](/docs/04_money/object/rebase.md)
         - Object manipulations

--- a/docs/04_money/README.md
+++ b/docs/04_money/README.md
@@ -17,7 +17,7 @@ There are *static* methods as well as *object* ones.
     - Calculations
         - [`add()`](/docs/04_money/object/add.md)
         - [`subtract()`](/docs/04_money/object/subtract.md)
-        - [`multiple()`](/docs/04_money/object/multiple.md)
+        - [`multiply()`](/docs/04_money/object/multiply.md)
         - [`divide()`](/docs/04_money/object/divide.md)
         - [`rebase()`](/docs/04_money/object/rebase.md)
     - Object manipulations

--- a/docs/04_money/object/clone.md
+++ b/docs/04_money/object/clone.md
@@ -18,7 +18,7 @@ $johnReward = $bobReward
     // John's reward is 1500 as long as Bob's one but John's reward is independent now
     ->clone()
     // Multiplies John's reward by 2 without affecting Bob's reward at all
-    ->multiple(2);
+    ->multiply(2);
 
 $bobReward->getPureAmount();    // 1500
 $johnReward->getPureAmount();   // 3000
@@ -33,7 +33,7 @@ $johnReward = $bobReward
     // Add for both John and Bob because John refers to Bob's object
     ->add(500)
     // Multiplies both John and Bob because John refers to Bob's object
-    ->multiple(2);
+    ->multiply(2);
 
 $bobReward->getPureAmount();    // 3000
 $johnReward->getPureAmount();   // 3000

--- a/docs/04_money/object/multiply.md
+++ b/docs/04_money/object/multiply.md
@@ -1,10 +1,10 @@
-# `multiple()`
+# `multiply()`
 
-multiples an amount from the money.
+multiplies an amount from the money.
 
 ## Methods
 
-### `multiple(float $number)`
+### `multiply(float $number)`
 **Parameters**:
 1. `float $number` - a number on which the money will be multiplied.
 
@@ -14,7 +14,7 @@ multiples an amount from the money.
 
 ```php
 $money = money(1000);   // "$ 100"
-$money->multiple(1.5);  // "$ 150"
+$money->multiply(1.5);  // "$ 150"
 ```
 
 ---

--- a/docs/upgrade/3.x_to_4.x.md
+++ b/docs/upgrade/3.x_to_4.x.md
@@ -6,3 +6,12 @@
 
 This version drops support of PHP < 8.1 and now supports Laravel 9.
 This was made in order to keep pace with new versions and use new features.
+
+## Methods
+
+### `multiple()`
+
+This method has been renamed to `multiply()` in order to be grammatically correct.
+
+Whenever you use it, you can take advantage of your IDE to replace this everywhere.
+Press `Ctrl`+`Shift`+`R`, select `Match case` and `Words` options, and replace all `multiple(` with `multiply(`. But first, check all found occurrences out.

--- a/src/Money.php
+++ b/src/Money.php
@@ -127,7 +127,7 @@ class Money implements MoneyInterface
         return $this;
     }
 
-    public function multiple(float $number): self
+    public function multiply(float $number): self
     {
         $this->amount = $this->getPureAmount() * $number;
         return $this;

--- a/src/PHPDocs/MoneyInterface.php
+++ b/src/PHPDocs/MoneyInterface.php
@@ -80,13 +80,13 @@ interface MoneyInterface
     public function subtract($money, int $origin = MoneySettings::ORIGIN_INT): Money;
 
     /**
-     * Multiples an amount from the money. It's like <p>
+     * Multiplies an amount from the money. It's like <p>
      * `$100 * 2 = $200` </p>
      * @param float $number <p>
      * A number on which the money will be multiplied </p>
      * @return Money
      */
-    public function multiple(float $number): Money;
+    public function multiply(float $number): Money;
 
     /**
      * Divides an amount from the money. It's like <p>

--- a/tests/Feature/ManipulatingMoneyNumberTest.php
+++ b/tests/Feature/ManipulatingMoneyNumberTest.php
@@ -262,7 +262,7 @@ class ManipulatingMoneyNumberTest extends TestCase
     public function moneyCanBeMultipliedByANumber()
     {
         $money = new Money(500);
-        $money->multiple(1.5);
+        $money->multiply(1.5);
 
         $this->assertEquals(750, $money->getPureAmount());
         $this->assertEquals('$ 75', $money->toString());

--- a/tests/Unit/MoneyTest.php
+++ b/tests/Unit/MoneyTest.php
@@ -124,7 +124,7 @@ class MoneyTest extends TestCase
             // $m2 is 1500 as long as $m1 but $m2 is independent now
             ->clone()
             // $m2 is 3000 whereas $m1 is still 1500
-            ->multiple(2);
+            ->multiply(2);
 
         $this->assertEquals(1500, $m1->getPureAmount());
         $this->assertEquals(3000, $m2->getPureAmount());


### PR DESCRIPTION
The method `multiple()` has been renamed to `multiply()` in order to be grammatically correct.