### PR TITLE
Extract Currencies from Currency

### DIFF
--- a/docs/03_currencies/get_currencies.md
+++ b/docs/03_currencies/get_currencies.md
@@ -4,19 +4,19 @@ Get all the chosen (current) currencies.
 
 ## Methods
 
-### `Currency::getCurrencies()`
+### `Currencies::get()`
 **Returns**: `Illuminate\Support\Collection`
 
-### `Currency::getCurrencyCodesArray()`
+### `Currencies::getCodesArray()`
 **Returns**: `array` as `["USD", "EUR", ...]`
 
 ## Usage
 
 ```php
-use PostScripton\Money\Currency;
+use PostScripton\Money\Currencies;
 
-Currency::getCurrencies();          // Collection of currencies
-Currency::getCurrencyCodesArray();  // ["USD", "EUR", ...]
+Currencies::get();              // Collection of currencies
+Currencies::getCodesArray();    // ["USD", "EUR", ...]
 ```
 
 ---

--- a/docs/upgrade/3.x_to_4.x.md
+++ b/docs/upgrade/3.x_to_4.x.md
@@ -244,6 +244,7 @@ It was decided to get rid of methods for setting a currency list from the code. 
 
 ### 🟧 `Currency::getCurrencies()`
 
-Now it returns not an array of ISO codes but a collection of currencies
+This method has been moved to [`Currencies` class](/docs/03_currencies/get_currencies.md):
 
-### 🟩 `Currency::getCurrencyCodesArray()`
+- `Currencies::get()`
+- `Currencies::getCodesArray()`

--- a/src/Currencies.php
+++ b/src/Currencies.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace PostScripton\Money;
+
+use Illuminate\Support\Collection;
+use PostScripton\Money\Enums\CurrencyList;
+
+class Currencies
+{
+    private static ?Collection $currencies = null;
+
+    public static function get(): Collection
+    {
+        if (is_null(self::$currencies)) {
+            self::$currencies = self::createCurrencies(self::loadCurrencies());
+        }
+
+        return self::$currencies;
+    }
+
+    public static function getCodesArray(): array
+    {
+        return self::get()
+            ->map(fn(Currency $currency) => $currency->getCode())
+            ->toArray();
+    }
+
+    private static function loadCurrencies(): Collection
+    {
+        $list = config('money.currency_list');
+
+        if (!is_array($list)) {
+            return self::getList($list);
+        }
+
+        // Custom currency list (array of strings)
+        return self::getList(CurrencyList::All)->filter(function (array $currency) use (&$list) {
+            if (empty($list)) {
+                return false;
+            }
+
+            foreach ($list as $item) {
+                if ($currency['iso_code'] === $item || $currency['num_code'] === $item) {
+                    $list = array_diff($list, [$item]);
+                    return true;
+                }
+            }
+
+            return false;
+        });
+    }
+
+    private static function createCurrencies(Collection $currencies): Collection
+    {
+        return $currencies->map(fn(array $currency) => new Currency($currency));
+    }
+
+    private static function getList(CurrencyList $currencyList): Collection
+    {
+        $list = collect(require $currencyList->path());
+
+        if ($currencyList !== CurrencyList::Custom) {
+            $customCurrencies = collect(config('money.custom_currencies'));
+            return $list->map(function (array $currency) use ($customCurrencies) {
+                $customCurrency = $customCurrencies->first(function (array $customCurrency) use ($currency) {
+                    return strtoupper($customCurrency['iso_code']) === strtoupper($currency['iso_code']) ||
+                        $customCurrency['num_code'] === $currency['num_code'];
+                });
+                return $customCurrency ?: $currency;
+            });
+        }
+
+        return $list;
+    }
+}

--- a/src/Currency.php
+++ b/src/Currency.php
@@ -2,9 +2,7 @@
 
 namespace PostScripton\Money;
 
-use Illuminate\Support\Collection;
 use PostScripton\Money\Enums\CurrencyDisplay;
-use PostScripton\Money\Enums\CurrencyList;
 use PostScripton\Money\Enums\CurrencyPosition;
 use PostScripton\Money\Exceptions\CurrencyDoesNotExistException;
 use PostScripton\Money\Exceptions\CurrencyHasWrongConstructorException;
@@ -13,13 +11,11 @@ use PostScripton\Money\Exceptions\ShouldPublishConfigFileException;
 
 class Currency
 {
-    // todo use collection instead of array
-    protected static array $currencies = [];
     private string $full_name;
     private string $name;
     private string $iso_code;
     private string $num_code;
-    private $symbol; // array or string
+    private array|string $symbol;
     private CurrencyPosition $position;
     private CurrencyDisplay $display;
     private ?int $preferred_symbol = null;
@@ -43,18 +39,17 @@ class Currency
         $this->symbol = $currency['symbol'];
         $this->position = $currency['position'] ?? CurrencyPosition::End;
         $this->display = CurrencyDisplay::Symbol;
-        $preferred_symbol = null;
     }
 
     public static function code(string $code): ?Currency
     {
         if (is_numeric($code)) {
-            $currency = self::getCurrencies()
-                ->filter(fn(Currency $currency) => $currency->getNumCode() === $code)
+            $currency = Currencies::get()
+                ->filter(fn(self $currency) => $currency->getNumCode() === $code)
                 ->first();
         } else {
-            $currency = self::getCurrencies()
-                ->filter(fn(Currency $currency) => $currency->getCode() === strtoupper($code))
+            $currency = Currencies::get()
+                ->filter(fn(self $currency) => $currency->getCode() === strtoupper($code))
                 ->first();
         }
 
@@ -168,30 +163,6 @@ class Currency
         return $this;
     }
 
-    public static function getCurrencies(): Collection
-    {
-        if (!self::$currencies) {
-            self::$currencies = self::createCurrencies(self::loadCurrencies());
-        }
-
-        return collect(self::$currencies);
-    }
-
-    public static function getCurrencyCodesArray(): array
-    {
-        return self::getCurrencies()
-            ->map(fn(self $currency) => $currency->getCode())
-            ->toArray();
-    }
-
-    /**
-     * @deprecated Will be removed due to no usage of it
-     */
-    public static function count(): int
-    {
-        return count(self::$currencies);
-    }
-
     /**
      * @throws ShouldPublishConfigFileException
      */
@@ -202,55 +173,5 @@ class Currency
         }
 
         return config('money.default_currency', 'USD');
-    }
-
-    private static function loadCurrencies(): array
-    {
-        $list = config('money.currency_list');
-
-        if (!is_array($list)) {
-            return self::getList($list);
-        }
-
-        // Custom currency list (array of strings)
-        return array_filter(self::getList(CurrencyList::All), function ($currency) use (&$list) {
-            if (empty($list)) {
-                return false;
-            }
-
-            foreach ($list as $item) {
-                if ($currency['iso_code'] === $item || $currency['num_code'] === $item) {
-                    $list = array_diff($list, [$item]);
-                    return true;
-                }
-            }
-
-            return false;
-        });
-    }
-
-    private static function createCurrencies(array $currencies): array
-    {
-        return array_map(function ($currency) {
-            return new self($currency);
-        }, $currencies);
-    }
-
-    private static function getList(CurrencyList $currencyList): array
-    {
-        $list = require $currencyList->path();
-
-        if ($currencyList !== CurrencyList::Custom) {
-            $customCurrencies = collect(config('money.custom_currencies'));
-            $list = array_map(function (array $currency) use ($customCurrencies) {
-                $customCurrency = $customCurrencies->first(function (array $customCurrency) use ($currency) {
-                    return strtoupper($customCurrency['iso_code']) === strtoupper($currency['iso_code']) ||
-                        $customCurrency['num_code'] === $currency['num_code'];
-                });
-                return $customCurrency ?: $currency;
-            }, $list);
-        }
-
-        return $list;
     }
 }

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -8,7 +8,7 @@ class Parser
 {
     public static function parse(string $money): Money
     {
-        $currencies = Currency::getCurrencies();
+        $currencies = Currencies::get();
         foreach ($currencies as $foundCurrency) {
             foreach ($foundCurrency->getSymbols() as $symbol) {
                 $symbols[] = $symbol;

--- a/tests/Unit/CurrencyTest.php
+++ b/tests/Unit/CurrencyTest.php
@@ -2,6 +2,7 @@
 
 namespace PostScripton\Money\Tests\Unit;
 
+use PostScripton\Money\Currencies;
 use PostScripton\Money\Currency;
 use PostScripton\Money\Enums\CurrencyPosition;
 use PostScripton\Money\Exceptions\CurrencyDoesNotExistException;
@@ -46,7 +47,7 @@ class CurrencyTest extends TestCase
     public function getAllTheCurrenciesAsArray()
     {
         $actual = require __DIR__ . '/../../src/Lists/popular_currencies.php';
-        $allCurrencies = Currency::getCurrencyCodesArray();
+        $allCurrencies = Currencies::getCodesArray();
 
         $this->assertCount(count($actual), $allCurrencies);
         $this->assertEquals(


### PR DESCRIPTION
It's been decided to extract some logic that relates to a collection from `Currency` into a separate class `Currencies`.

Before:
```php
Currency::getCurrenies(); // ['USD', 'EUR', 'RUB', ...]
```

After:
```php
Currencies::get(); // Collection of currencies
Currencies::getCodesArray(); // ['USD', 'EUR', 'RUB', ...]
```