### PR TITLE
[3.x] Fix cast nullable column to money

### DIFF
--- a/src/Casts/MoneyCast.php
+++ b/src/Casts/MoneyCast.php
@@ -3,16 +3,30 @@
 namespace PostScripton\Money\Casts;
 
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use PostScripton\Money\Money;
 
 class MoneyCast implements CastsAttributes
 {
     public function get($model, string $key, $value, array $attributes)
     {
+        if (is_null($value)) {
+            return null;
+        }
+
         return money($value);
     }
 
     public function set($model, string $key, $value, array $attributes)
     {
+        if (is_null($value)) {
+            return null;
+        }
+
+        $isMonetary = gettype($value) === 'object' && $value instanceof Money;
+        if (! $isMonetary) {
+            $value = money($value);
+        }
+
         return $value->upload();
     }
 }

--- a/tests/Unit/MoneyCastTest.php
+++ b/tests/Unit/MoneyCastTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace PostScripton\Money\Tests\Unit;
+
+use Illuminate\Database\Eloquent\Model;
+use PostScripton\Money\Casts\MoneyCast;
+use PostScripton\Money\Money;
+use PostScripton\Money\Tests\TestCase;
+
+class MoneyCastTest extends TestCase
+{
+    public function testGet(): void
+    {
+        $product1 = $this->getTestingModel();
+        $product2 = $this->getTestingModel();
+        $product2->price = money('12345');
+
+        $this->assertNull($product1->price);
+        $this->assertInstanceOf(Money::class, $product2->price);
+        $this->assertEquals('$ 1 234.5', $product2->price->toString());
+    }
+
+    public function testSet(): void
+    {
+        $product1 = $this->getTestingModel();
+        $product1->price = money('12345');
+        $product2 = $this->getTestingModel();
+        $product2->price = '12345';
+        $product3 = $this->getTestingModel();
+        $product3->price = 12345;
+        $product4 = $this->getTestingModel();
+        $product4->price = null;
+        $expectedMoneyString = '$ 1 234.5';
+
+        $this->assertInstanceOf(Money::class, $product1->price);
+        $this->assertEquals($expectedMoneyString, $product1->price->toString());
+        $this->assertInstanceOf(Money::class, $product2->price);
+        $this->assertEquals($expectedMoneyString, $product2->price->toString());
+        $this->assertInstanceOf(Money::class, $product3->price);
+        $this->assertEquals($expectedMoneyString, $product3->price->toString());
+        $this->assertNull($product4->price);
+    }
+
+    private function getTestingModel(): Model
+    {
+        return new class extends Model {
+            protected $fillable = [
+                'price',
+            ];
+
+            protected $casts = [
+                'price' => MoneyCast::class,
+            ];
+        };
+    }
+}


### PR DESCRIPTION
There was a bug when a nullable column was cast to monetary object.

<img width="709" alt="image" src="https://user-images.githubusercontent.com/68855126/198398638-7c8aed6a-bf3a-41ae-86fb-a6adb7aa9aef.png">

(The `test` property is a nullable integer column in a model `Order`)