### PR TITLE
Add `absolute()` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ After all, the config file at `config/money.php` should be modified for your own
         - Object manipulations
             - [`floor()`](/docs/04_money/object/floor.md)
             - [`ceil()`](/docs/04_money/object/ceil.md)
+            - [`absolute()`](/docs/04_money/object/absolute.md)
             - [`clone()`](/docs/04_money/object/clone.md)
         - Logical operations
             - [`isSameCurrency()`](/docs/04_money/object/isSameCurrency.md)
@@ -108,14 +109,14 @@ After all, the config file at `config/money.php` should be modified for your own
             - [`service()`](/docs/04_money/object/service.md)
             - [`convertInto()`](/docs/04_money/object/convertInto.md)
             - [`toString()`](/docs/04_money/object/toString.md)
-7. [API services](/docs/05_services/README.md)
+6. [API services](/docs/05_services/README.md)
     - [Add your own](/docs/05_services/add.md)
 
 ## Contributing
 
 Contributions are **welcome** and will be fully **credited**.
 
-We accept contributions via Pull Requests on [Github](https://github.com/PostScripton/laravel-money/).
+We accept contributions via Pull Requests on [GitHub](https://github.com/PostScripton/laravel-money/).
 
 ### Pull Requests
 

--- a/docs/04_money/README.md
+++ b/docs/04_money/README.md
@@ -23,6 +23,7 @@ There are *static* methods as well as *object* ones.
     - Object manipulations
         - [`floor()`](/docs/04_money/object/floor.md)
         - [`ceil()`](/docs/04_money/object/ceil.md)
+        - [`absolute()`](/docs/04_money/object/absolute.md)
         - [`clone()`](/docs/04_money/object/clone.md)
     - Logical operations
         - [`isSameCurrency()`](/docs/04_money/object/isSameCurrency.md)

--- a/docs/04_money/object/absolute.md
+++ b/docs/04_money/object/absolute.md
@@ -1,0 +1,19 @@
+# `absolute()`
+
+turns the amount of the monetary object into an absolute value. `$ -10.25 -> $ 10.25`
+
+## Methods
+
+### `absolute()`
+**Returns**: `Money`
+
+## Usage
+
+```php
+$money = money('-102500');  // $ -10.3
+$money->absolute();         // $ 10.3
+```
+
+---
+
+📌 Back to the [contents](/docs/04_money/README.md).

--- a/src/Money.php
+++ b/src/Money.php
@@ -159,6 +159,13 @@ class Money implements MoneyInterface
         return $this;
     }
 
+    public function absolute(): self
+    {
+        $this->amount = ltrim($this->amount, '-');
+
+        return $this;
+    }
+
     public function isSameCurrency(Money $money): bool
     {
         return $this->getCurrency()->getCode() === $money->getCurrency()->getCode();

--- a/src/PHPDocs/MoneyInterface.php
+++ b/src/PHPDocs/MoneyInterface.php
@@ -119,6 +119,13 @@ interface MoneyInterface
     public function ceil(): self;
 
     /**
+     * Turns the amount of the monetary object into an absolute value <p>
+     * `$ -10.25 -> $ 10.25` </p>
+     * @return self
+     */
+    public function absolute(): self;
+
+    /**
      * Checks whether two money objects have the same currency
      * @param Money $money
      * @return bool

--- a/tests/Unit/MoneyTest.php
+++ b/tests/Unit/MoneyTest.php
@@ -82,6 +82,19 @@ class MoneyTest extends TestCase
         $this->assertEquals('$ 11', $money->toString());
     }
 
+    /**
+     * @test
+     * @dataProvider absoluteDataProvider
+     */
+    public function moneyAbsoluteAmount(string $negative, string $absolute): void
+    {
+        $money = money($negative);
+
+        $money->absolute();
+
+        $this->assertEquals($absolute, $money->getPureAmount());
+    }
+
     /** @test */
     public function correctWayToHandleImmutableMoneyObjects(): void
     {
@@ -98,5 +111,23 @@ class MoneyTest extends TestCase
         $this->assertEquals('1500000', $m1->getPureAmount());
         $this->assertEquals('3000000', $m2->getPureAmount());
         $this->assertFalse($m1->equals($m2));
+    }
+
+    protected function absoluteDataProvider(): array
+    {
+        return [
+            [
+                'negative' => '-12345',
+                'absolute' => '12345',
+            ],
+            [
+                'negative' => '12345',
+                'absolute' => '12345',
+            ],
+            [
+                'negative' => '-0',
+                'absolute' => '0',
+            ],
+        ];
     }
 }


### PR DESCRIPTION
This PR brings up a new `absolute()` method.
It simply turns an amount of a monetary object into an absolute value.

```php
$money = money('-102500');  // $ -10.3
$money->absolute();         // $ 10.3
```