### PR TITLE
Add `money_parse()` helper function

### DIFF
--- a/docs/04_money/static/parse.md
+++ b/docs/04_money/static/parse.md
@@ -26,15 +26,17 @@ use PostScripton\Money\Money;
 // Simply parse an amount with the default currency.
 
 Money::parse('1 234.5678');
+money_parse('1 234.5678');
 
 // Or parse an amount with a currency
 
-Money::parse('$100');
-Money::parse('€ 100', 'EUR');
-Money::parse('£-100', 'GBP');
-Money::parse('GBP -100', 'GBP');
-Money::parse('-100 ₽', 'RUB');
-Money::parse('-100 RUB', '643');
+money_parse('$100');
+money_parse('$100');
+money_parse('€ 100', 'EUR');
+money_parse('£-100', 'GBP');
+money_parse('GBP -100', 'GBP');
+money_parse('-100 ₽', 'RUB');
+money_parse('-100 RUB', '643');
 ```
 
 Unknown currency throws the exception because this currency is not expected.

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -6,7 +6,7 @@ use PostScripton\Money\MoneySettings;
 
 if (! function_exists('money')) {
     /**
-     * Creates Money object
+     * Creates a monetary object
      * @param string $amount
      * @param null $currency
      * @param null $settings
@@ -15,6 +15,19 @@ if (! function_exists('money')) {
     function money(string $amount, $currency = null, $settings = null): Money
     {
         return new Money($amount, $currency, $settings);
+    }
+}
+
+if (! function_exists('money_parse')) {
+    /**
+     * Parses the string and turns it into a monetary instance
+     * @param string $money
+     * @param string|null $currencyCode
+     * @return Money
+     */
+    function money_parse(string $money, ?string $currencyCode = null): Money
+    {
+        return Money::parse($money, $currencyCode);
     }
 }
 

--- a/tests/Feature/DifferenceBetweenMoneyTest.php
+++ b/tests/Feature/DifferenceBetweenMoneyTest.php
@@ -20,8 +20,8 @@ class DifferenceBetweenMoneyTest extends TestCase
      */
     public function difference(string $first, string $second, string $result): void
     {
-        $m1 = Money::parse($first);
-        $m2 = Money::parse($second);
+        $m1 = money_parse($first);
+        $m2 = money_parse($second);
 
         $diff = $m1->difference($m2);
 


### PR DESCRIPTION
From now on you can use a parser functionality not only by calling `Money::parse()` but also by using a new helper function `money_parse()`.

```php
use PostScripton\Money\Money;

Money::parse('$ 1.25');

money_parse('$ 1.25');
```