### PR TITLE
Fix formatter must not trim zeros in integers

### DIFF
--- a/src/Formatters/DefaultMoneyFormatter.php
+++ b/src/Formatters/DefaultMoneyFormatter.php
@@ -118,9 +118,9 @@ class DefaultMoneyFormatter implements MoneyFormatter
             $this->thousandsSeparator,
         );
 
-        if (! $this->endsWithZero) {
+        if (! $this->endsWithZero && str_contains($amount, $this->decimalSeparator)) {
             $amount = preg_replace('/0+$/', '', $amount);
-            $amount = rtrim($amount, '.');
+            $amount = rtrim($amount, $this->decimalSeparator);
         }
 
         return $amount;

--- a/tests/Unit/Formatters/DefaultMoneyFormatterTest.php
+++ b/tests/Unit/Formatters/DefaultMoneyFormatterTest.php
@@ -22,6 +22,22 @@ class DefaultMoneyFormatterTest extends TestCase
         $this->assertEquals($result, $formatter->format($money));
     }
 
+    public function testFormatOnlyDecimalZerosMustBeTrimmedButNotIntegerOnes(): void
+    {
+        $money = money_parse('1500');
+
+        $formatterForInteger = (new DefaultMoneyFormatter())
+            ->decimals(0)
+            ->endsWithZero(false);
+        $formatterForDecimals = (new DefaultMoneyFormatter())
+            ->decimalSeparator('#')
+            ->decimals(2)
+            ->endsWithZero(false);
+
+        $this->assertEquals('$ 1 500', $formatterForInteger->format($money));
+        $this->assertEquals('$ 1 500', $formatterForDecimals->format($money));
+    }
+
     protected function formatterDataProvider(): array
     {
         return [


### PR DESCRIPTION
There was a bug when formatter is set `endsWithZero(false)`, it cut integer zeros.

For example, `1 500` was cut to `1 5`.