### PR TITLE
Fix parser substring without decimals

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -28,7 +28,11 @@ class Parser
 
         $amount = str_replace(' ', '', $result['amount']);
         $amount = (string) ($amount * Money::getDefaultDivisor()); // todo rework it with bcmath later
-        $amount = substr($amount, strpos($amount, '.'));
+        $amount = substr(
+            $amount,
+            offset: 0,
+            length: strpos($amount, '.') ?: null
+        );
 
         return money($amount, $currency);
     }


### PR DESCRIPTION
Though it is impossible due to the `Rules\Money` limit of decimal places (now it's `4`), in the future it may be greater (for example, `6`) and it will cause unexcepted results.