### PR TITLE
Add macros 'money' to Blueprint

### DIFF
--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -9,7 +9,7 @@ The integer type is **the only choice** because of database performance, precisi
 ```php
 Schema::create('products', function (Blueprint $table) {
     $table->id();
-    $table->bigInteger('price')->default(0);
+    $table->money('price')->default(0);
     $table->timestamps();
 });
 ```
@@ -21,7 +21,7 @@ If you know that you'll be storing a giant **positive** numbers, you can take a 
 Schema::create('payments', function (Blueprint $table) {
     $table->id();
     $table->foreignId('user_id')->constrained();
-    $table->unsignedBigInteger('amount');
+    $table->unsignedMoney('amount');
     $table->enum('transaction_type', ['debit', 'credit']);
     $table->enum('type', ['invoice', 'fee', 'order', 'admin']);
 });

--- a/src/MoneyServiceProvider.php
+++ b/src/MoneyServiceProvider.php
@@ -3,6 +3,7 @@
 namespace PostScripton\Money;
 
 use Exception;
+use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rules\Enum;
 use InvalidArgumentException;
@@ -53,6 +54,13 @@ class MoneyServiceProvider extends PackageServiceProvider
         Currency::setDefault(currency(config('money.default_currency', 'USD')));
 
         Validator::extend(MoneyRule::RULE_NAME, (MoneyRule::class . '@passes'), app(MoneyRule::class)->message());
+
+        Blueprint::macro('money', function (string $column = 'amount') {
+            return $this->bigInteger($column)->nullable();
+        });
+        Blueprint::macro('unsignedMoney', function (string $column = 'amount') {
+            return $this->unsignedBigInteger($column)->nullable();
+        });
     }
 
     protected function registerRateExchanger(): void


### PR DESCRIPTION
Usage example

```php
Schema::create('orders', function (Blueprint $table): void {
    $table->id();
    // ...
    $table->money('price'); // Or $table->money(); creating a bigint column named amount
    $table->timestamps();
});
```