### PR TITLE
Change money to money_parse in MoneyCast

### DIFF
--- a/src/Casts/MoneyCast.php
+++ b/src/Casts/MoneyCast.php
@@ -24,7 +24,7 @@ class MoneyCast implements CastsAttributes
 
         $isMonetary = gettype($value) === 'object' && $value instanceof Money;
         if (! $isMonetary) {
-            $value = money($value);
+            $value = money_parse($value);
         }
 
         return $value->getAmount();

--- a/tests/Unit/MoneyCastTest.php
+++ b/tests/Unit/MoneyCastTest.php
@@ -12,11 +12,11 @@ class MoneyCastTest extends TestCase
     public function testCast(): void
     {
         $product1 = $this->getTestingModel();
-        $product1->price = money('12345000');
+        $product1->price = money(12345000);
         $product2 = $this->getTestingModel();
-        $product2->price = '12345000';
+        $product2->price = '1 234.5';
         $product3 = $this->getTestingModel();
-        $product3->price = 12345000;
+        $product3->price = money('12345000');
         $product4 = $this->getTestingModel();
         $product4->price = null;
         $expectedMoneyString = '$ 1 234.5';


### PR DESCRIPTION
This pr will fix the incorrect parsing of the string into a money object with decimal places

### Reproduce a problem

1. Set  in model cast to MoneyCast
2. In model factory use `$this->faker->randomFloat(2, 100, 999)`
3. Run the factory and you will see that there are only integers in the table column without decimals after the comma. For example, the number **200** is stored in the table, but it should be **2000000**

![telegram-cloud-photo-size-2-5307758470759564527-x](https://user-images.githubusercontent.com/14270217/210597950-a3284c7f-9287-48aa-85e6-263865709d9e.jpg)
![telegram-cloud-photo-size-2-5307758470759564528-y](https://user-images.githubusercontent.com/14270217/210597971-92018a32-7748-4a5b-aba3-f9efe182425a.jpg)
![telegram-cloud-photo-size-2-5307758470759564529-y](https://user-images.githubusercontent.com/14270217/210597986-4fef5c50-dac0-4edd-b3e8-7639ac26c7b2.jpg)
